### PR TITLE
Update authenticate method to be fluent

### DIFF
--- a/src/Pricehubble.php
+++ b/src/Pricehubble.php
@@ -138,7 +138,6 @@ class Pricehubble
         if (isset($response['access_token'])) {
             $this->setApiToken($response['access_token']);
         }
-        
         return $this;
     }
 

--- a/src/Pricehubble.php
+++ b/src/Pricehubble.php
@@ -128,7 +128,7 @@ class Pricehubble
      *
      * @throws \Exception
      */
-    public function authenticate(string $username, string $password, int $timeout = self::TIMEOUT): void
+    public function authenticate(string $username, string $password, int $timeout = self::TIMEOUT): self
     {
         $response = $this->makeRequest('post', 'https://api.pricehubble.com/auth/login/credentials', [
             'username' => $username,
@@ -138,6 +138,8 @@ class Pricehubble
         if (isset($response['access_token'])) {
             $this->setApiToken($response['access_token']);
         }
+        
+        return $this;
     }
 
     /**

--- a/src/Pricehubble.php
+++ b/src/Pricehubble.php
@@ -138,6 +138,7 @@ class Pricehubble
         if (isset($response['access_token'])) {
             $this->setApiToken($response['access_token']);
         }
+
         return $this;
     }
 


### PR DESCRIPTION
This way you can do : `$priceHubble = (new Pricehubble())->authenticate(getenv('PRICEHUBBLE_LOGIN'), getenv('PRICEHUBBLE_PASSWORD'));` and use it afterwards.

In my case in Wordpress : 

```php
$priceHubble = (new Pricehubble())->authenticate(getenv('PRICEHUBBLE_LOGIN'), getenv('PRICEHUBBLE_PASSWORD'));

add_filter('publimmo_edit_property_before_save', function($property) use ($priceHubble) {
    // Do some price hubble stuff
}, 10, 3 );
```