### PR TITLE
update PHP versions to run on PHP 8.5

### DIFF
--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: php-cs-fixer, cs2pr
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
       - uses: actions/checkout@v4
       - run: composer install --prefer-dist
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           tools: composer:v2
       - uses: actions/checkout@v4
       - run: composer install --prefer-dist

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: php-cs-fixer, cs2pr
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
       - uses: actions/checkout@v4
       - run: composer install --prefer-dist
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.5'
+          php-version: '8.3'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
       - uses: actions/checkout@v4
       - run: composer install --prefer-dist
@@ -52,6 +52,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
+          php-version: '8.3'
           tools: composer:v2
       - uses: actions/checkout@v4
       - run: composer install --prefer-dist

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -19,19 +19,6 @@ jobs:
       - run: composer install --prefer-dist
       - run: ./vendor/bin/php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
-  phpcpd:
-    name: phpcpd
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-      - uses: actions/checkout@v4
-      - run: composer install --prefer-dist
-      - run: ./vendor/bin/phpcpd ./ --suffix .php --suffix .inc --suffix .test --exclude vendor --exclude bin --exclude tests
-
   psalm:
     name: psalm
     runs-on: ubuntu-latest

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
           tools: php-cs-fixer, cs2pr
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
       - uses: actions/checkout@v4
       - run: composer install --prefer-dist
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
       - uses: actions/checkout@v4
       - run: composer install --prefer-dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
         - name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.3', '8.4', '8.5']
     steps:
         - name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
           with:
               php_version: ${{ matrix.php-versions }}
               version: 2
+              args: --ignore-platform-reqs
+
         - run: XDEBUG_MODE=coverage ./vendor/bin/phpunit
         - name: Upload coverage results to Coveralls
           env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
         - name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,6 @@ jobs:
           with:
               php_version: ${{ matrix.php-versions }}
               version: 2
-              args: --ignore-platform-reqs
 
         - run: XDEBUG_MODE=coverage ./vendor/bin/phpunit
         - name: Upload coverage results to Coveralls

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
     steps:
         - name: Setup PHP
           uses: shivammathur/setup-php@v2

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ composer.lock
 
 # Ignore log & cache files
 .php-cs-fixer.cache
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update PHP versions to run on PHP 8.5
 - upgrade vimeo/psalm (4.30.0 => 5.26.1)
 - update symfony/dotenv (v5.4.48 => v7.4.0)
+- upgrade vimeo/psalm (5.26.1 => 6.15.1)
 
 ### Removed
 - removed support PHP 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- update PHP versions to run on PHP 8.5
 
 ## [1.0.4] - 2025-05-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - removed support PHP 8.0
+- removed support PHP 8.1
 
 ## [1.0.4] - 2025-05-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - removed support PHP 8.0
 - removed support PHP 8.1
 - removed support PHP 8.2
+- remove phpcpd as abandoned
 
 ## [1.0.4] - 2025-05-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - removed support PHP 8.0
 - removed support PHP 8.1
+- removed support PHP 8.2
 
 ## [1.0.4] - 2025-05-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Security
 - update PHP versions to run on PHP 8.5
-- upgrade vimeo/psalm (4.30.0 => 5.26.1)
 - update symfony/dotenv (v5.4.48 => v7.4.0)
-- upgrade vimeo/psalm (5.26.1 => 6.15.1)
+- upgrade vimeo/psalm (4.30.0 = => 6.15.1)
 
 ### Removed
 - removed support PHP 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Security
 - update PHP versions to run on PHP 8.5
+- upgrade vimeo/psalm (4.30.0 => 5.26.1)
 
 ## [1.0.4] - 2025-05-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update PHP versions to run on PHP 8.5
 - update symfony/dotenv (v5.4.48 => v7.4.0)
 - upgrade vimeo/psalm (4.30.0 = => 6.15.1)
+- upgrade phpunit/php-code-coverage (9.2.32 => 12.5.3)
+- upgrade phpunit/phpunit (9.6.34 => 12.5.14)
 
 ### Removed
 - removed support PHP 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - update PHP versions to run on PHP 8.5
 - upgrade vimeo/psalm (4.30.0 => 5.26.1)
+- update symfony/dotenv (v5.4.48 => v7.4.0)
 
 ### Removed
 - removed support PHP 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - update PHP versions to run on PHP 8.5
 - upgrade vimeo/psalm (4.30.0 => 5.26.1)
 
+### Removed
+- removed support PHP 8.0
+
 ## [1.0.4] - 2025-05-02
 ### Added
 - add tests on PHP 8.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,14 +34,6 @@ Automatically fix coding standards
 ./vendor/bin/php-cs-fixer fix -v --using-cache=no
 ```
 
-### Improve global code quality using PHPCPD (Code duplication)
-
-Copy/Paste Detector
-
-```bash
-./vendor/bin/phpcpd ./web/modules/custom
-```
-
 ### Enforce code standards with git hooks
 
 Maintaining code quality by adding the custom post-commit hook to yours.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,22 @@ There are a small number of PHPUnit unit tests. Unit testing against an API is o
 
 ## Developing
 
+## 🧪 Running tests
+
+Run the test suite without code coverage (no Xdebug required):
+
+```bash
+./vendor/bin/phpunit --no-coverage
+```
+
+Run the test suite with code coverage (requires [Xdebug](https://xdebug.org/) or [PCOV](https://github.com/krakjoe/pcov)):
+
+```bash
+XDEBUG_MODE=coverage ./vendor/bin/phpunit
+```
+
+> **Note:** Running `./vendor/bin/phpunit` without `--no-coverage` and without a coverage driver will fail with _"No code coverage driver available"_. Use `--no-coverage` for day-to-day local development.
+
 ## 🚔 Check Symfony 4 coding standards & best practices
 
 You need to run composer before using [FriendsOfPHP/PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).

--- a/bin/post-commit
+++ b/bin/post-commit
@@ -1,8 +1,5 @@
 echo "\n🚔  \033[0;32mRunning Code Sniffer Symfony ...\033[0m"
 ./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -v --dry-run --using-cache=no --format=checkstyle
 
-echo "\n🛂  \033[0;32mRunning PHP Copy/Paste Detector ...\033[0m"
-./vendor/bin/phpcpd ./ --exclude=vendor --exclude=bin --exclude=tests
-
 echo "\n🙏  \033[0;32mRunning Psalm ...\033[0m"
 ./vendor/bin/psalm

--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,14 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6",
+    "phpunit/phpunit": "^12",
     "symfony/dotenv": "^7.4",
     "friendsofphp/php-cs-fixer": "^3.94",
     "phpmd/phpmd": "^2.6",
     "php-coveralls/php-coveralls": "^2.9",
     "php-mock/php-mock-phpunit": "^2.15",
     "vimeo/psalm": "^6.0",
-    "phpunit/php-code-coverage": "^9.2"
+    "phpunit/php-code-coverage": "^12"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "phpmd/phpmd": "^2.6",
     "php-coveralls/php-coveralls": "^2.9",
     "php-mock/php-mock-phpunit": "^2.15",
-    "vimeo/psalm": "^5.26",
+    "vimeo/psalm": "^6.0",
     "phpunit/php-code-coverage": "^9.2"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,14 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9",
+    "phpunit/phpunit": "^9.6",
     "symfony/dotenv": "^7.4",
     "friendsofphp/php-cs-fixer": "^3.94",
     "phpmd/phpmd": "^2.6",
-    "sebastian/phpcpd": "^6.0",
-    "php-coveralls/php-coveralls": "^2.1",
-    "php-mock/php-mock-phpunit": "^2.6",
+    "php-coveralls/php-coveralls": "^2.9",
+    "php-mock/php-mock-phpunit": "^2.15",
     "vimeo/psalm": "^5.26",
-    "phpunit/php-code-coverage": "^9"
+    "phpunit/php-code-coverage": "^9.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Super-simple, minimum abstraction Pricehubble API v1.x wrapper, in PHP",
   "license": "MIT",
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "ext-curl": "*",
     "ext-json": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9",
-    "symfony/dotenv": "^5.4",
+    "symfony/dotenv": "^7.4",
     "friendsofphp/php-cs-fixer": "^3.94",
     "phpmd/phpmd": "^2.6",
     "sebastian/phpcpd": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Super-simple, minimum abstraction Pricehubble API v1.x wrapper, in PHP",
   "license": "MIT",
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "ext-curl": "*",
     "ext-json": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Super-simple, minimum abstraction Pricehubble API v1.x wrapper, in PHP",
   "license": "MIT",
   "require": {
-    "php": ">=8.2",
+    "php": ">=8.3",
     "ext-curl": "*",
     "ext-json": "*"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
   "require-dev": {
     "phpunit/phpunit": "^9",
     "symfony/dotenv": "^5.4",
-    "friendsofphp/php-cs-fixer": "^3.21",
+    "friendsofphp/php-cs-fixer": "^3.94",
     "phpmd/phpmd": "^2.6",
     "sebastian/phpcpd": "^6.0",
     "php-coveralls/php-coveralls": "^2.1",
     "php-mock/php-mock-phpunit": "^2.6",
-    "vimeo/psalm": "^4.10",
+    "vimeo/psalm": "^5.26",
     "phpunit/php-code-coverage": "^9"
   },
   "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,12 @@
          colors="true"
          failOnRisky="true"
          failOnWarning="true"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnPhpunitNotices="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true">
     <testsuites>
         <testsuite name="Pricehubble Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
          failOnRisky="true"
          failOnWarning="true"
@@ -8,17 +7,20 @@
     <testsuites>
         <testsuite name="Pricehubble Test Suite">
             <directory suffix=".php">./tests/</directory>
+            <exclude>./tests/Traits/</exclude>
         </testsuite>
     </testsuites>
-    <logging>
-        <log type="coverage-clover" target="./build/logs/clover.xml"/>
-        <log type="coverage-html" target="./build/logs/coverage-html"/>
-    </logging>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <source>
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
+    <coverage>
+        <report>
+            <clover outputFile="./build/logs/clover.xml"/>
+            <html outputDirectory="./build/logs/coverage-html"/>
+        </report>
+    </coverage>
     <php>
         <!-- Temporarily preventing https://github.com/xdebug/xdebug/pull/699 -->
         <const name="XDEBUG_CC_UNUSED"  value=""/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="7"
     resolveFromConfigFile="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Pricehubble.php
+++ b/src/Pricehubble.php
@@ -12,6 +12,8 @@ use Antistatique\Pricehubble\Resource\ResourceInterface;
  *
  * @see self::authenticate to obtain one.
  *
+ * @psalm-api
+ *
  * @method \Antistatique\Pricehubble\Resource\Valuation        valuation()
  * @method \Antistatique\Pricehubble\Resource\PointsOfInterest pointsOfInterest()
  */
@@ -107,6 +109,8 @@ class Pricehubble
 
     /**
      * Proxies all Pricehubble API Class and Methods.
+     *
+     * @psalm-suppress PossiblyUnusedParam $arguments is required by PHP's __call signature
      */
     public function __call(string $name, array $arguments): ResourceInterface
     {

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -46,6 +46,7 @@ abstract class AbstractResource implements ResourceInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getPricehubble(): Pricehubble
     {
         return $this->pricehubble;

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -6,6 +6,8 @@ use Antistatique\Pricehubble\Pricehubble;
 
 /**
  * Pricehubble base API class.
+ *
+ * @psalm-api
  */
 abstract class AbstractResource implements ResourceInterface
 {

--- a/src/Resource/PointsOfInterest.php
+++ b/src/Resource/PointsOfInterest.php
@@ -7,6 +7,8 @@ use Antistatique\Pricehubble\Pricehubble;
 /**
  * The Pricehubble Points of Interest API class.
  *
+ * @psalm-api
+ *
  * @see https://docs.pricehubble.com/international/pois/
  */
 final class PointsOfInterest extends AbstractResource

--- a/src/Resource/Valuation.php
+++ b/src/Resource/Valuation.php
@@ -7,6 +7,8 @@ use Antistatique\Pricehubble\Pricehubble;
 /**
  * The Pricehubble Valuation API class.
  *
+ * @psalm-api
+ *
  * @see https://docs.pricehubble.com/international/valuation/
  */
 final class Valuation extends AbstractResource

--- a/tests/Unit/AbstractResourceTest.php
+++ b/tests/Unit/AbstractResourceTest.php
@@ -4,30 +4,28 @@ namespace Antistatique\Pricehubble\Tests\Unit;
 
 use Antistatique\Pricehubble\Pricehubble;
 use Antistatique\Pricehubble\Resource\AbstractResource;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass \Antistatique\Pricehubble\Resource\AbstractResource
- *
- * @group pricehubble
- * @group pricehubble_unit
- *
  * @internal
  */
+#[CoversClass(AbstractResource::class)]
+#[CoversMethod(AbstractResource::class, '__construct')]
+#[CoversMethod(AbstractResource::class, 'setPricehubble')]
+#[CoversMethod(AbstractResource::class, 'getPricehubble')]
+#[Group('pricehubble')]
+#[Group('pricehubble_unit')]
 final class AbstractResourceTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     */
     public function testConstructorArgumentCount(): void
     {
         $this->expectException(\ArgumentCountError::class);
         new class extends AbstractResource {};
     }
 
-    /**
-     * @covers ::__construct
-     */
     public function testConstructor(): void
     {
         $pricehubble = new Pricehubble();
@@ -35,7 +33,7 @@ final class AbstractResourceTest extends TestCase
         $mock = $this->getMockBuilder(AbstractResource::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['setPricehubble'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         // Set expectations for constructor calls.
         $mock->expects($this->once())
@@ -48,26 +46,16 @@ final class AbstractResourceTest extends TestCase
         $constructor->invoke($mock, $pricehubble);
     }
 
-    /**
-     * @covers ::setPricehubble
-     */
     public function testSetPricehubbleReturnsExpected(): void
     {
         $pricehubble = new Pricehubble();
+        $testResource = new class(new Pricehubble()) extends AbstractResource {};
 
-        // Get mock, without the constructor being called
-        $mock = $this->getMockBuilder(AbstractResource::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
-
-        $mock->setPricehubble($pricehubble);
-        $result = $mock->getPricehubble();
+        $testResource->setPricehubble($pricehubble);
+        $result = $testResource->getPricehubble();
         self::assertSame($result, $pricehubble);
     }
 
-    /**
-     * @covers ::getPricehubble
-     */
     public function testGetPricehubbleReturnsExpected(): void
     {
         $pricehubble = new Pricehubble();

--- a/tests/Unit/CurlAvailabilitiesTest.php
+++ b/tests/Unit/CurlAvailabilitiesTest.php
@@ -30,7 +30,7 @@ final class CurlAvailabilitiesTest extends TestCase
 
     public function testcurlNotAvailable(): void
     {
-        $pricehubbleMock = $this->createMock(Pricehubble::class);
+        $pricehubbleMock = $this->createStub(Pricehubble::class);
         $pricehubbleMock->method('isCurlAvailable')->willReturn(false);
 
         $this->expectException(\RuntimeException::class);
@@ -40,14 +40,10 @@ final class CurlAvailabilitiesTest extends TestCase
         $pricehubbleMock->method('isCurlAvailable')->willReturn(true);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::isCurlAvailable
-     */
     #[DoesNotPerformAssertions]
     public function testCurlAvailable(): void
     {
-        $pricehubbleMock = $this->createMock(Pricehubble::class);
+        $pricehubbleMock = $this->createStub(Pricehubble::class);
         $pricehubbleMock->method('isCurlAvailable')->willReturn(true);
         $pricehubbleMock->__construct();
     }

--- a/tests/Unit/CurlAvailabilitiesTest.php
+++ b/tests/Unit/CurlAvailabilitiesTest.php
@@ -4,33 +4,30 @@ namespace Antistatique\Pricehubble\Tests\Unit;
 
 use Antistatique\Pricehubble\Pricehubble;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass \Antistatique\Pricehubble\Pricehubble
- *
- * @group pricehubble
- * @group pricehubble_unit
- *
  * @internal
  */
+#[CoversClass(Pricehubble::class)]
+#[CoversMethod(Pricehubble::class, '__construct')]
+#[CoversMethod(Pricehubble::class, 'isCurlAvailable')]
+#[Group('pricehubble')]
+#[Group('pricehubble_unit')]
 final class CurlAvailabilitiesTest extends TestCase
 {
     use PHPMock;
 
-    /**
-     * @covers ::isCurlAvailable
-     */
     public function testIsCurlAvailable(): void
     {
         $pricehubble = new Pricehubble();
         $this->assertTrue($pricehubble->isCurlAvailable());
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::isCurlAvailable
-     */
     public function testcurlNotAvailable(): void
     {
         $pricehubbleMock = $this->createMock(Pricehubble::class);
@@ -46,9 +43,8 @@ final class CurlAvailabilitiesTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::isCurlAvailable
-     *
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testCurlAvailable(): void
     {
         $pricehubbleMock = $this->createMock(Pricehubble::class);

--- a/tests/Unit/PricehubbleAttachRequestPayloadTest.php
+++ b/tests/Unit/PricehubbleAttachRequestPayloadTest.php
@@ -5,16 +5,18 @@ namespace Antistatique\Pricehubble\Tests\Unit;
 use Antistatique\Pricehubble\Pricehubble;
 use Antistatique\Pricehubble\Tests\Traits\TestPrivateTrait;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass \Antistatique\Pricehubble\Pricehubble
- *
- * @group pricehubble
- * @group pricehubble_unit
- *
  * @internal
  */
+#[CoversClass(Pricehubble::class)]
+#[CoversMethod(Pricehubble::class, 'attachRequestPayload')]
+#[Group('pricehubble')]
+#[Group('pricehubble_unit')]
 final class PricehubbleAttachRequestPayloadTest extends TestCase
 {
     use TestPrivateTrait;
@@ -37,9 +39,6 @@ final class PricehubbleAttachRequestPayloadTest extends TestCase
         $this->pricehubble = new Pricehubble();
     }
 
-    /**
-     * @covers ::attachRequestPayload
-     */
     public function testAttachRequestPayload()
     {
         self::assertSame([], $this->pricehubble->getLastRequest());

--- a/tests/Unit/PricehubbleTest.php
+++ b/tests/Unit/PricehubbleTest.php
@@ -6,16 +6,34 @@ use Antistatique\Pricehubble\Pricehubble;
 use Antistatique\Pricehubble\Resource\AbstractResource;
 use Antistatique\Pricehubble\Tests\Traits\TestPrivateTrait;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @coversDefaultClass \Antistatique\Pricehubble\Pricehubble
- *
- * @group pricehubble
- * @group pricehubble_unit
- *
  * @internal
  */
+#[CoversClass(Pricehubble::class)]
+#[CoversMethod(Pricehubble::class, '__construct')]
+#[CoversMethod(Pricehubble::class, '__call')]
+#[CoversMethod(Pricehubble::class, 'authenticate')]
+#[CoversMethod(Pricehubble::class, 'determineSuccess')]
+#[CoversMethod(Pricehubble::class, 'findHttpStatus')]
+#[CoversMethod(Pricehubble::class, 'formatResponse')]
+#[CoversMethod(Pricehubble::class, 'getApiToken')]
+#[CoversMethod(Pricehubble::class, 'getHeadersAsArray')]
+#[CoversMethod(Pricehubble::class, 'getLastError')]
+#[CoversMethod(Pricehubble::class, 'getLastRequest')]
+#[CoversMethod(Pricehubble::class, 'getLastResponse')]
+#[CoversMethod(Pricehubble::class, 'makeRequest')]
+#[CoversMethod(Pricehubble::class, 'prepareStateForRequest')]
+#[CoversMethod(Pricehubble::class, 'setApiToken')]
+#[CoversMethod(Pricehubble::class, 'setResponseState')]
+#[CoversMethod(Pricehubble::class, 'success')]
+#[Group('pricehubble')]
+#[Group('pricehubble_unit')]
 final class PricehubbleTest extends TestCase
 {
     use TestPrivateTrait;
@@ -38,16 +56,6 @@ final class PricehubbleTest extends TestCase
         $this->pricehubble = new Pricehubble();
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::success
-     * @covers ::getLastError
-     * @covers ::getLastResponse
-     * @covers ::getLastRequest
-     * @covers ::setResponseState
-     * @covers ::getHeadersAsArray
-     * @covers ::prepareStateForRequest
-     */
     public function testInstantiation(): void
     {
         $pricehubble = new Pricehubble();
@@ -60,10 +68,6 @@ final class PricehubbleTest extends TestCase
         self::assertSame([], $pricehubble->getLastRequest());
     }
 
-    /**
-     * @covers ::formatResponse
-     * @covers ::getLastResponse
-     */
     public function testFormatResponseJson(): void
     {
         $response['body'] = '{"access_token": "74126eab0a9048d993bda4b1b55ae074", "expires_in": 43200}';
@@ -77,9 +81,6 @@ final class PricehubbleTest extends TestCase
         ], $result);
     }
 
-    /**
-     * @covers ::formatResponse
-     */
     public function testFormatResponseEmptyBody()
     {
         $result = $this->callPrivateMethod($this->pricehubble, 'formatResponse', [[]]);
@@ -87,18 +88,12 @@ final class PricehubbleTest extends TestCase
         self::assertEmpty($this->pricehubble->getLastResponse());
     }
 
-    /**
-     * @covers ::__call
-     */
     public function testMagicCallReturnsExpected(): void
     {
         $valuation = $this->pricehubble->valuation();
         self::assertInstanceOf(AbstractResource::class, $valuation);
     }
 
-    /**
-     * @covers ::__call
-     */
     public function testMagicCallReturnsException(): void
     {
         $this->expectException(\BadMethodCallException::class);
@@ -106,10 +101,6 @@ final class PricehubbleTest extends TestCase
         $this->pricehubble->foo();
     }
 
-    /**
-     * @covers ::setApiToken
-     * @covers ::getApiToken
-     */
     public function testSetApiToken(): void
     {
         self::assertEmpty($this->pricehubble->getApiToken());
@@ -117,15 +108,12 @@ final class PricehubbleTest extends TestCase
         self::assertEquals('api-token', $this->pricehubble->getApiToken());
     }
 
-    /**
-     * @covers ::authenticate
-     */
     public function testAuthenticateOnSuccessSetApiToken(): void
     {
         $mock = $this->getMockBuilder(Pricehubble::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['makeRequest', 'setApiToken'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $mock->expects(self::once())
             ->method('makeRequest')
@@ -141,15 +129,12 @@ final class PricehubbleTest extends TestCase
         $mock->authenticate('user', 'password');
     }
 
-    /**
-     * @covers ::authenticate
-     */
     public function testAuthenticateOnError(): void
     {
         $mock = $this->getMockBuilder(Pricehubble::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['makeRequest', 'setApiToken'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $mock->expects(self::once())
             ->method('makeRequest')
@@ -165,9 +150,6 @@ final class PricehubbleTest extends TestCase
         $mock->authenticate('user', 'password');
     }
 
-    /**
-     * @covers ::setResponseState
-     */
     public function testSetResponseState()
     {
         $response = json_decode(file_get_contents(__DIR__.'/../responses/partials/complete.json'), true, 512, JSON_THROW_ON_ERROR);
@@ -198,9 +180,6 @@ final class PricehubbleTest extends TestCase
 ', $response['body']);
     }
 
-    /**
-     * @covers ::setResponseState
-     */
     public function testSetResponseStateError()
     {
         $curl_error_mock = $this->getFunctionMock('Antistatique\Pricehubble', 'curl_error');
@@ -214,9 +193,6 @@ final class PricehubbleTest extends TestCase
         ]);
     }
 
-    /**
-     * @covers ::getHeadersAsArray
-     */
     public function testGetHeadersAsArray()
     {
         $headers_string = '
@@ -241,11 +217,7 @@ Content-Type: application/json';
         ], $headers);
     }
 
-    /**
-     * @covers ::findHttpStatus
-     *
-     * @dataProvider providerHttpStatus
-     */
+    #[DataProvider('providerHttpStatus')]
     public function testFindHttpStatus($response, $formatted_response, $expected_code)
     {
         $code = $this->callPrivateMethod($this->pricehubble, 'findHttpStatus', [
@@ -261,7 +233,7 @@ Content-Type: application/json';
      * @return array
      *               Variation of HTTP Status response
      */
-    public function providerHttpStatus()
+    public static function providerHttpStatus()
     {
         return [
             [
@@ -307,11 +279,7 @@ Content-Type: application/json';
         ];
     }
 
-    /**
-     * @covers ::determineSuccess
-     *
-     * @dataProvider providerStatus200
-     */
+    #[DataProvider('providerStatus200')]
     public function testDetermineSuccessStatus200($code)
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -336,7 +304,7 @@ Content-Type: application/json';
      * @return array
      *               Variation of HTTP Status response
      */
-    public function providerStatus200()
+    public static function providerStatus200()
     {
         return [
             [
@@ -351,9 +319,6 @@ Content-Type: application/json';
         ];
     }
 
-    /**
-     * @covers ::determineSuccess
-     */
     public function testDetermineSuccessErrorMessage()
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -373,9 +338,6 @@ Content-Type: application/json';
         self::assertEquals('ERROR 400: Unsupported country code.', $pricehubble_mock->getLastError());
     }
 
-    /**
-     * @covers ::determineSuccess
-     */
     public function testDetermineSuccessErrorMessageDescription()
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -395,9 +357,6 @@ Content-Type: application/json';
         self::assertEquals('ERROR 401: invalid_token: The access token is invalid or has expired.', $pricehubble_mock->getLastError());
     }
 
-    /**
-     * @covers ::determineSuccess
-     */
     public function testDetermineSuccessTimeout()
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -415,9 +374,6 @@ Content-Type: application/json';
         ]);
     }
 
-    /**
-     * @covers ::determineSuccess
-     */
     public function testDetermineSuccessUnknown()
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -437,9 +393,6 @@ Content-Type: application/json';
         self::assertEquals('Unknown error, call getLastResponse() to find out what happened.', $pricehubble_mock->getLastError());
     }
 
-    /**
-     * @covers ::determineSuccess
-     */
     public function testDetermineSuccess401MissingToken()
     {
         $response = json_decode(file_get_contents(__DIR__.'/../responses/exceptions/401-missing-token.json'), true, 512, JSON_THROW_ON_ERROR);
@@ -456,9 +409,6 @@ Content-Type: application/json';
         ]);
     }
 
-    /**
-     * @covers ::determineSuccess
-     */
     public function testDetermineSuccess403MissingProperty()
     {
         $response = json_decode(file_get_contents(__DIR__.'/../responses/exceptions/403-missing-property.json'), true, 512, JSON_THROW_ON_ERROR);
@@ -474,9 +424,6 @@ Content-Type: application/json';
         ]);
     }
 
-    /**
-     * @covers ::determineSuccess
-     */
     public function testDetermineSuccess403Forbidden()
     {
         $response = json_decode(file_get_contents(__DIR__.'/../responses/exceptions/403-forbidden.json'), true, 512, JSON_THROW_ON_ERROR);
@@ -491,8 +438,6 @@ Content-Type: application/json';
     }
 
     /**
-     * @covers ::determineSuccess
-     *
      * Cover the scenario of inconsistency on Pricehubble API with nested message.
      */
     public function testDetermineSuccess403ForbiddenNested()
@@ -508,9 +453,6 @@ Content-Type: application/json';
         ]);
     }
 
-    /**
-     * @covers ::prepareStateForRequest
-     */
     public function testPrepareStateForRequest()
     {
         $this->callPrivateMethod($this->pricehubble, 'prepareStateForRequest', [
@@ -534,9 +476,6 @@ Content-Type: application/json';
         ], $this->pricehubble->getLastRequest());
     }
 
-    /**
-     * @covers ::makeRequest
-     */
     public function testMakeRequestMalformedResponse(): void
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -566,9 +505,6 @@ Content-Type: application/json';
         ]);
     }
 
-    /**
-     * @covers ::makeRequest
-     */
     public function testMakeRequestGet(): void
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -606,11 +542,7 @@ Content-Type: application/json';
         ]);
     }
 
-    /**
-     * @covers ::makeRequest
-     *
-     * @dataProvider providerHttpVerbs
-     */
+    #[DataProvider('providerHttpVerbs')]
     public function testMakeRequestByVerbs(string $verb): void
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -648,9 +580,6 @@ Content-Type: application/json';
         ]);
     }
 
-    /**
-     * @covers ::makeRequest
-     */
     public function testMakeRequestArgsLanguage(): void
     {
         $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
@@ -693,7 +622,7 @@ Content-Type: application/json';
      *
      * @return iterable Variation of HTTP Verbs
      */
-    public function providerHttpVerbs(): iterable
+    public static function providerHttpVerbs(): iterable
     {
         yield ['post'];
         yield ['delete'];

--- a/tests/Unit/PricehubbleTest.php
+++ b/tests/Unit/PricehubbleTest.php
@@ -488,11 +488,11 @@ Content-Type: application/json';
 
         $pricehubble_mock->expects($this->once())
             ->method('setResponseState')
-            ->with($this->isType('array'), $this->isType('string'), $this->anything());
+            ->with($this->isArray(), $this->isString(), $this->anything());
 
         $pricehubble_mock->expects($this->once())
             ->method('formatResponse')
-            ->with($this->isType('array'));
+            ->with($this->isArray());
 
         $pricehubble_mock->expects($this->never())
             ->method('determineSuccess');
@@ -521,17 +521,17 @@ Content-Type: application/json';
 
         $pricehubble_mock->expects($this->once())
             ->method('setResponseState')
-            ->with($this->isType('array'), $this->isType('string'), $this->anything())
+            ->with($this->isArray(), $this->isString(), $this->anything())
         ;
 
         $pricehubble_mock->expects($this->once())
             ->method('formatResponse')
-            ->with($this->isType('array'))
+            ->with($this->isArray())
             ->willReturn(['foo' => 'bar']);
 
         $pricehubble_mock->expects($this->once())
             ->method('determineSuccess')
-            ->with($this->isType('array'), $this->isType('array'), $this->isType('integer'))
+            ->with($this->isArray(), $this->isArray(), $this->isInt())
             ->willReturn(true);
 
         $curl_exec_mock = $this->getFunctionMock('Antistatique\Pricehubble', 'curl_exec');
@@ -559,17 +559,17 @@ Content-Type: application/json';
 
         $pricehubble_mock->expects($this->once())
             ->method('setResponseState')
-            ->with($this->isType('array'), $this->isType('string'), $this->anything())
+            ->with($this->isArray(), $this->isString(), $this->anything())
         ;
 
         $pricehubble_mock->expects($this->once())
             ->method('formatResponse')
-            ->with($this->isType('array'))
+            ->with($this->isArray())
             ->willReturn(['foo' => 'bar']);
 
         $pricehubble_mock->expects($this->once())
             ->method('determineSuccess')
-            ->with($this->isType('array'), $this->isType('array'), $this->isType('integer'))
+            ->with($this->isArray(), $this->isArray(), $this->isInt())
             ->willReturn(true);
 
         $curl_exec_mock = $this->getFunctionMock('Antistatique\Pricehubble', 'curl_exec');
@@ -596,17 +596,17 @@ Content-Type: application/json';
 
         $pricehubble_mock->expects($this->once())
           ->method('setResponseState')
-          ->with($this->isType('array'), $this->isType('string'), $this->anything())
+          ->with($this->isArray(), $this->isString(), $this->anything())
         ;
 
         $pricehubble_mock->expects($this->once())
           ->method('formatResponse')
-          ->with($this->isType('array'))
+          ->with($this->isArray())
           ->willReturn(['foo' => 'bar']);
 
         $pricehubble_mock->expects($this->once())
           ->method('determineSuccess')
-          ->with($this->isType('array'), $this->isType('array'), $this->isType('integer'))
+          ->with($this->isArray(), $this->isArray(), $this->isInt())
           ->willReturn(true);
 
         $curl_exec_mock = $this->getFunctionMock('Antistatique\Pricehubble', 'curl_exec');

--- a/tests/Unit/Resource/PointsOfInterestTest.php
+++ b/tests/Unit/Resource/PointsOfInterestTest.php
@@ -4,19 +4,19 @@ namespace Antistatique\Pricehubble\Tests\Unit\Resource;
 
 use Antistatique\Pricehubble\Pricehubble;
 use Antistatique\Pricehubble\Resource\AbstractResource;
+use Antistatique\Pricehubble\Resource\PointsOfInterest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \Antistatique\Pricehubble\Resource\PointsOfInterest
- *
- * @group pricehubble
- * @group pricehubble_unit
- */
+#[CoversClass(PointsOfInterest::class)]
+#[CoversMethod(Pricehubble::class, '__call')]
+#[CoversMethod(PointsOfInterest::class, 'gather')]
+#[Group('pricehubble')]
+#[Group('pricehubble_unit')]
 class PointsOfInterestTest extends TestCase
 {
-    /**
-     * @covers \Antistatique\Pricehubble\Pricehubble::__call
-     */
     public function testCallReturnsExpected(): void
     {
         $pricehubble = new Pricehubble();
@@ -24,9 +24,6 @@ class PointsOfInterestTest extends TestCase
         self::assertInstanceOf(AbstractResource::class, $resource);
     }
 
-    /**
-     * @covers ::gather
-     */
     public function testGatherReturnsExpected(): void
     {
         $response = json_decode(file_get_contents(__DIR__.'/../../responses/pois.json'), true, 512, JSON_THROW_ON_ERROR);

--- a/tests/Unit/Resource/ValuationTest.php
+++ b/tests/Unit/Resource/ValuationTest.php
@@ -4,19 +4,20 @@ namespace Antistatique\Pricehubble\Tests\Unit\Resource;
 
 use Antistatique\Pricehubble\Pricehubble;
 use Antistatique\Pricehubble\Resource\AbstractResource;
+use Antistatique\Pricehubble\Resource\Valuation;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \Antistatique\Pricehubble\Resource\Valuation
- *
- * @group pricehubble
- * @group pricehubble_unit
- */
+#[CoversClass(Valuation::class)]
+#[CoversMethod(Pricehubble::class, '__call')]
+#[CoversMethod(Valuation::class, 'full')]
+#[CoversMethod(Valuation::class, 'light')]
+#[Group('pricehubble')]
+#[Group('pricehubble_unit')]
 class ValuationTest extends TestCase
 {
-    /**
-     * @covers \Antistatique\Pricehubble\Pricehubble::__call
-     */
     public function testCallReturnsExpected(): void
     {
         $pricehubble = new Pricehubble();
@@ -24,9 +25,6 @@ class ValuationTest extends TestCase
         self::assertInstanceOf(AbstractResource::class, $resource);
     }
 
-    /**
-     * @covers ::full
-     */
     public function testFullReturnsExpected(): void
     {
         $response = json_decode(file_get_contents(__DIR__.'/../../responses/valuation-full.json'), true, 512, JSON_THROW_ON_ERROR);
@@ -74,9 +72,6 @@ class ValuationTest extends TestCase
         $pricehubble_mock->valuation()->full($fullParams);
     }
 
-    /**
-     * @covers ::light
-     */
     public function testLightReturnsExpected(): void
     {
         $response = json_decode(file_get_contents(__DIR__.'/../../responses/valuation-light.json'), true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
### 💬 Description
update PHP versions to run on PHP 8.5

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
