### PR TITLE
chore(deps): drop unused phpmd/phpmd dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- chore(deps): drop unused phpmd/phpmd dev dependency
 
 ## [1.2.0] - 2026-05-01
 ### Security

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "phpunit/phpunit": "^13",
     "symfony/dotenv": "^8.0",
     "friendsofphp/php-cs-fixer": "^3.94",
-    "phpmd/phpmd": "^2.6",
     "php-coveralls/php-coveralls": "^2.9",
     "php-mock/php-mock-phpunit": "^2.15",
     "vimeo/psalm": "^6.0",


### PR DESCRIPTION
### 💬 Description
chore(deps): drop unused phpmd/phpmd dev dependency

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)

