### PR TITLE
fix(php85): remove deprecated calls and fail the suite on new ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fix(php85): remove deprecated calls and fail the suite on new ones
 
 ## [1.2.0] - 2026-05-01
 ### Security

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
          colors="true"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
          stopOnFailure="false"
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnPhpunitDeprecations="true"

--- a/src/Pricehubble.php
+++ b/src/Pricehubble.php
@@ -464,7 +464,7 @@ class Pricehubble
         $response = $this->setResponseState($response, $response_content, $curl);
         $formattedResponse = $this->formatResponse($response);
 
-        curl_close($curl);
+        unset($curl);
 
         if (!$formattedResponse) {
             return false;

--- a/tests/Traits/TestPrivateTrait.php
+++ b/tests/Traits/TestPrivateTrait.php
@@ -23,7 +23,6 @@ trait TestPrivateTrait
     {
         $class = new \ReflectionClass($obj);
         $method = $class->getMethod($name);
-        $method->setAccessible(true);
 
         return $method->invokeArgs($obj, $args);
     }


### PR DESCRIPTION
### 💬 Description
fix(php85): remove deprecated calls and fail the suite on new ones

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)

