### PR TITLE
fix(linter): raise psalm errorLevel (7 => 2) and drop dead config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - fix(composer): bound the php constraint (>=8.4 => ^8.4)
+- fix(linter): raise psalm errorLevel (7 => 2) and drop dead config
 
 ### Fixed
 - fix(ci): run workflows on pull_request so fork contributions get CI
 - fix(dependabot): remove config that silently disabled all version updates
 - fix(php85): remove deprecated calls and fail the suite on new ones
 - fix(curl): type cURL handles as CurlHandle and check curl_init failure
+- fix(http): reject malformed URLs instead of failing with a TypeError
+- fix(auth): send the Authorization header for a falsy-but-valid token
 
 ### Added
 - test(resource): assert verb, URL and timeout passed to makeRequest

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="7"
+    errorLevel="2"
     resolveFromConfigFile="true"
-    findUnusedBaselineEntry="true"
     findUnusedCode="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -10,9 +9,5 @@
 >
     <projectFiles>
         <directory name="src" />
-        <ignoreFiles>
-            <directory name="vendor" />
-            <directory name="bin" />
-        </ignoreFiles>
     </projectFiles>
 </psalm>

--- a/src/Pricehubble.php
+++ b/src/Pricehubble.php
@@ -24,21 +24,21 @@ class Pricehubble
      *
      * @var string
      */
-    public const BASE_URL = 'https://api.pricehubble.com/api/v1';
+    public const string BASE_URL = 'https://api.pricehubble.com/api/v1';
 
     /**
      * Default timeout limit for request in seconds.
      *
      * @var int
      */
-    public const TIMEOUT = 10;
+    public const int TIMEOUT = 10;
 
     /**
      * Pricehubble FQD class to be automatically discovered.
      *
      * @var string
      */
-    private const FQN_CLASS = '\\Antistatique\\Pricehubble\\Resource\\';
+    private const string FQN_CLASS = '\\Antistatique\\Pricehubble\\Resource\\';
 
     /**
      * SSL Verification.
@@ -122,7 +122,13 @@ class Pricehubble
                 throw new \InvalidArgumentException(sprintf('Undefined API class %s', $apiClass));
             }
 
-            return new $apiFQNClass($this);
+            $resource = new $apiFQNClass($this);
+
+            if (!$resource instanceof ResourceInterface) {
+                throw new \InvalidArgumentException(sprintf('API class %s is not a %s', $apiClass, ResourceInterface::class));
+            }
+
+            return $resource;
         } catch (\InvalidArgumentException $e) {
             throw new \BadMethodCallException(sprintf('Undefined method %s', $name));
         }
@@ -403,8 +409,10 @@ class Pricehubble
         ];
 
         // add Authorization token for any verb.
-        if ($this->getApiToken()) {
-            $httpHeader[] = "Authorization: Bearer {$this->getApiToken()}";
+        $apiToken = $this->getApiToken();
+
+        if (null !== $apiToken && '' !== $apiToken) {
+            $httpHeader[] = "Authorization: Bearer {$apiToken}";
         }
 
         if (isset($args['language'])) {
@@ -472,13 +480,14 @@ class Pricehubble
 
         unset($curl);
 
-        if (!$formattedResponse) {
+        if (false === $formattedResponse) {
             return false;
         }
 
-        $isSuccess = $this->determineSuccess($response, $formattedResponse, $timeout);
+        // Throws on any non-2xx status; the return value is always true here.
+        $this->determineSuccess($response, $formattedResponse, $timeout);
 
-        return \is_array($formattedResponse) ? $formattedResponse : $isSuccess;
+        return $formattedResponse;
     }
 
     /**
@@ -497,6 +506,13 @@ class Pricehubble
     protected function prepareStateForRequest(string $http_verb, string $url, int $timeout): array
     {
         $parts = parse_url($url);
+
+        if (false === $parts) {
+            $this->lastError = sprintf('Malformed URL: %s', $url);
+
+            throw new \InvalidArgumentException($this->lastError);
+        }
+
         $this->lastError = '';
 
         $this->requestSuccessful = false;

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -26,7 +26,7 @@ abstract class AbstractResource implements ResourceInterface
      */
     public function __construct(Pricehubble $pricehubble)
     {
-        $this->setPricehubble($pricehubble);
+        $this->pricehubble = $pricehubble;
     }
 
     /**

--- a/tests/Unit/AbstractResourceTest.php
+++ b/tests/Unit/AbstractResourceTest.php
@@ -29,21 +29,16 @@ final class AbstractResourceTest extends TestCase
     public function testConstructor(): void
     {
         $pricehubble = new Pricehubble();
-        // Get mock, without the constructor being called
-        $mock = $this->getMockBuilder(AbstractResource::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['setPricehubble'])
-            ->getMock();
 
-        // Set expectations for constructor calls.
-        $mock->expects($this->once())
-            ->method('setPricehubble')
-            ->with($pricehubble);
+        $testResource = new class($pricehubble) extends AbstractResource {
+            #[\Override]
+            public function setPricehubble(Pricehubble $pricehubble): self
+            {
+                return $this;
+            }
+        };
 
-        // Now call the constructor
-        $reflectedClass = new \ReflectionClass(AbstractResource::class);
-        $constructor = $reflectedClass->getConstructor();
-        $constructor->invoke($mock, $pricehubble);
+        self::assertSame($pricehubble, $testResource->getPricehubble());
     }
 
     public function testSetPricehubbleReturnsExpected(): void

--- a/tests/Unit/PricehubbleTest.php
+++ b/tests/Unit/PricehubbleTest.php
@@ -496,9 +496,12 @@ Content-Type: application/json';
             ->method('setResponseState')
             ->with($this->isArray(), $this->isString(), $this->anything());
 
+        // formatResponse() returns FALSE - not null - when the body cannot be
+        // decoded.
         $pricehubble_mock->expects($this->once())
             ->method('formatResponse')
-            ->with($this->isArray());
+            ->with($this->isArray())
+            ->willReturn(false);
 
         $pricehubble_mock->expects($this->never())
             ->method('determineSuccess');
@@ -521,7 +524,7 @@ Content-Type: application/json';
             ->method('prepareStateForRequest')
             ->with('get', 'https://example.org', 10);
 
-        $pricehubble_mock->expects($this->exactly(2))
+        $pricehubble_mock->expects($this->atLeastOnce())
             ->method('getApiToken')
             ->willReturn('api-token');
 
@@ -559,7 +562,7 @@ Content-Type: application/json';
             ->method('prepareStateForRequest')
             ->with($verb, 'https://example.org', 10);
 
-        $pricehubble_mock->expects($this->exactly(2))
+        $pricehubble_mock->expects($this->atLeastOnce())
             ->method('getApiToken')
             ->willReturn('api-token');
 
@@ -596,7 +599,7 @@ Content-Type: application/json';
           ->method('prepareStateForRequest')
           ->with('get', 'https://example.org', 10);
 
-        $pricehubble_mock->expects($this->exactly(2))
+        $pricehubble_mock->expects($this->atLeastOnce())
           ->method('getApiToken')
           ->willReturn('api-token');
 
@@ -634,5 +637,57 @@ Content-Type: application/json';
         yield ['delete'];
         yield ['patch'];
         yield ['put'];
+    }
+
+    /**
+     * A bearer token of "0" is a valid token but a falsy PHP string.
+     */
+    public function testMakeRequestSendsAuthorizationHeaderForFalsyToken(): void
+    {
+        self::assertContains('Authorization: Bearer 0', $this->captureRequestHeaders('0'));
+    }
+
+    public function testMakeRequestOmitsAuthorizationHeaderWithoutToken(): void
+    {
+        $headers = $this->captureRequestHeaders('');
+
+        foreach ($headers as $header) {
+            self::assertStringStartsNotWith('Authorization:', $header);
+        }
+    }
+
+    /**
+     * Run makeRequest() with the given token and return the CURLOPT_HTTPHEADER value.
+     *
+     * @return array<int, string>
+     */
+    private function captureRequestHeaders(string $token): array
+    {
+        $pricehubble_mock = $this->getMockBuilder(Pricehubble::class)
+            ->onlyMethods(['getApiToken', 'prepareStateForRequest', 'setResponseState', 'formatResponse', 'determineSuccess'])
+            ->getMock();
+        $pricehubble_mock->expects($this->atLeastOnce())->method('getApiToken')->willReturn($token);
+        $pricehubble_mock->method('formatResponse')->willReturn(['foo' => 'bar']);
+        $pricehubble_mock->method('determineSuccess')->willReturn(true);
+
+        $captured = [];
+        $curl_setopt_mock = $this->getFunctionMock('Antistatique\\Pricehubble', 'curl_setopt');
+        $curl_setopt_mock->expects($this->atLeastOnce())
+            ->willReturnCallback(static function ($curl, int $option, $value) use (&$captured): bool {
+                if (\CURLOPT_HTTPHEADER === $option) {
+                    $captured = $value;
+                }
+
+                return true;
+            });
+
+        $curl_exec_mock = $this->getFunctionMock('Antistatique\\Pricehubble', 'curl_exec');
+        $curl_exec_mock->expects($this->once())->willReturn('body');
+
+        $this->callPrivateMethod($pricehubble_mock, 'makeRequest', [
+            'get', 'https://example.org',
+        ]);
+
+        return $captured;
     }
 }


### PR DESCRIPTION
### 💬 Description
fix(linter): raise psalm errorLevel (7 => 2) and drop dead config

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)

