### PR TITLE
fix(api): tighten getApiToken/getLastError return types and unmask __call errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(curl): type cURL handles as CurlHandle and check curl_init failure
 - fix(http): reject malformed URLs instead of failing with a TypeError
 - fix(auth): send the Authorization header for a falsy-but-valid token
+- fix(api): tighten getApiToken/getLastError return types and unmask __call errors
 
 ### Added
 - test(resource): assert verb, URL and timeout passed to makeRequest
+- test(coverage): cover the curl_init, parse_url and resource-type guards
 
 ## [1.2.0] - 2026-05-01
 ### Security

--- a/README.md
+++ b/README.md
@@ -163,4 +163,11 @@ If you suspect you're sending data in the wrong format, you can look at what was
 print_r($pricehubble->getLastRequest());
 ```
 
-If your server's CA root certificates are not up to date you may find that SSL verification fails and you don't get a response. The correction solution for this [is not to disable SSL verification](http://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/). The solution is to update your certificates. If you can't do that, there's an option at the top of the class file. Please don't just switch it off without at least attempting to update your certs -- that's lazy and dangerous. You're not a lazy, dangerous developer are you?
+If your server's CA root certificates are not up to date you may find that SSL verification fails and you don't get a response. The correction solution for this [is not to disable SSL verification](http://snippets.webaware.com.au/howto/stop-turning-off-curlopt_ssl_verifypeer-and-fix-your-php-config/). The solution is to update your certificates. If you can't do that, the `$verifySsl` public property turns the check off:
+
+```php
+$pricehubble = new Pricehubble();
+$pricehubble->verifySsl = false;
+```
+
+Please don't just switch it off without at least attempting to update your certs -- that's lazy and dangerous. You're not a lazy, dangerous developer are you?

--- a/src/Pricehubble.php
+++ b/src/Pricehubble.php
@@ -114,24 +114,20 @@ class Pricehubble
      */
     public function __call(string $name, array $arguments): ResourceInterface
     {
-        try {
-            $apiClass = ucfirst($name);
-            $apiFQNClass = self::FQN_CLASS.$apiClass;
+        $apiClass = ucfirst($name);
+        $apiFQNClass = self::FQN_CLASS.$apiClass;
 
-            if (false === class_exists($apiFQNClass)) {
-                throw new \InvalidArgumentException(sprintf('Undefined API class %s', $apiClass));
-            }
-
-            $resource = new $apiFQNClass($this);
-
-            if (!$resource instanceof ResourceInterface) {
-                throw new \InvalidArgumentException(sprintf('API class %s is not a %s', $apiClass, ResourceInterface::class));
-            }
-
-            return $resource;
-        } catch (\InvalidArgumentException $e) {
+        if (false === class_exists($apiFQNClass)) {
             throw new \BadMethodCallException(sprintf('Undefined method %s', $name));
         }
+
+        $resource = new $apiFQNClass($this);
+
+        if (!$resource instanceof ResourceInterface) {
+            throw new \BadMethodCallException(sprintf('API class %s is not a %s', $apiClass, ResourceInterface::class));
+        }
+
+        return $resource;
     }
 
     /**
@@ -166,9 +162,10 @@ class Pricehubble
      * If something didn't work, this contain the string describing the problem.
      *
      * @return bool|string
-     *                     Describing the error
+     *                     The string describing the error, or FALSE when the
+     *                     last request did not record one
      */
-    public function getLastError()
+    public function getLastError(): bool|string
     {
         return $this->lastError ?: false;
     }
@@ -213,9 +210,11 @@ class Pricehubble
     /**
      * Get the API token for restricted API calls.
      *
-     * @return string|null $token The Pricehubble token authorized for restricted API calls
+     * @return string
+     *                The Pricehubble token authorized for restricted API calls,
+     *                or an empty string when no token has been set yet
      */
-    public function getApiToken(): ?string
+    public function getApiToken(): string
     {
         return $this->apiAuthToken;
     }
@@ -411,7 +410,7 @@ class Pricehubble
         // add Authorization token for any verb.
         $apiToken = $this->getApiToken();
 
-        if (null !== $apiToken && '' !== $apiToken) {
+        if ('' !== $apiToken) {
             $httpHeader[] = "Authorization: Bearer {$apiToken}";
         }
 

--- a/tests/Unit/PricehubbleTest.php
+++ b/tests/Unit/PricehubbleTest.php
@@ -4,12 +4,15 @@ namespace Antistatique\Pricehubble\Tests\Unit;
 
 use Antistatique\Pricehubble\Pricehubble;
 use Antistatique\Pricehubble\Resource\AbstractResource;
+use Antistatique\Pricehubble\Resource\ResourceInterface;
 use Antistatique\Pricehubble\Tests\Traits\TestPrivateTrait;
 use phpmock\phpunit\PHPMock;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -689,5 +692,57 @@ Content-Type: application/json';
         ]);
 
         return $captured;
+    }
+
+    /**
+     * class_exists() proves the class is there, not that it is a resource.
+     */
+    public function testMagicCallRejectsClassThatIsNotAResource(): void
+    {
+        $fqn = 'Antistatique\\Pricehubble\\Resource\\NotAResource';
+
+        if (!class_exists($fqn, false)) {
+            eval('namespace Antistatique\\Pricehubble\\Resource; class NotAResource {}');
+        }
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('API class NotAResource is not a '.ResourceInterface::class);
+
+        $this->pricehubble->notAResource();
+    }
+
+    /**
+     * parse_url() returns FALSE for a malformed URL; feeding that into the
+     * request state used to fail with "Unsupported operand types: bool + array".
+     */
+    public function testMakeRequestThrowsOnMalformedUrl(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Malformed URL: http://');
+
+        $this->callPrivateMethod($this->pricehubble, 'makeRequest', [
+            'get', 'http://',
+        ]);
+    }
+
+    /**
+     * curl_init() returns FALSE when a session cannot be allocated.
+     *
+     * php-mock cannot intercept a call site that an earlier test in this
+     * process has already executed, so this runs in its own process.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testMakeRequestThrowsWhenCurlCannotBeInitialised(): void
+    {
+        $curl_init_mock = $this->getFunctionMock('Antistatique\\Pricehubble', 'curl_init');
+        $curl_init_mock->expects($this->once())->willReturn(false);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to initialise a cURL session.');
+
+        $this->callPrivateMethod($this->pricehubble, 'makeRequest', [
+            'get', 'https://example.org',
+        ]);
     }
 }


### PR DESCRIPTION
### 💬 Description
- fix(api): tighten getApiToken/getLastError return types and unmask __call errors

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)

